### PR TITLE
QSE-21: Update selector from object to map

### DIFF
--- a/modules/kubernetes-deployment/vars.tf
+++ b/modules/kubernetes-deployment/vars.tf
@@ -105,7 +105,7 @@ variable "max_unavailable" {
 
 variable "selector" {
   description = "A label query over pods that should match the Replicas count. Label keys and values that must match in order to be controlled by this deployment. Must match labels (`metadata.0.labels`)."
-  type        = object
+  type        = map(string)
   default     = null
 }
 


### PR DESCRIPTION
This is to remediate :
  on .terraform/modules/logstash_deployment/modules/kubernetes-deployment/vars.tf line 108, in variable "selector":
 108:   type        = object

The object type constructor requires one argument specifying the attribute
types and values as a map.

it seems selector has to exactly match the value of labels and hence should be equal to map(string)